### PR TITLE
Fix typo that prevents reproducing mb2-ssd-lite model on VOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The code to re-produce the model:
 
 ```bash
 wget -P models https://storage.googleapis.com/models-hao/mb2-imagenet-71_8.pth
-python train_ssd.py --dataset_type voc  --datasets ~/data/VOC0712/VOC2007 ~/data/VOC0712/VOC2012 --validation_dataset ~/data/VOC0712/test/VOC2007/ --net mb2-ssd-lite --base_net models/mb2-imagenet-71_8.pth  --scheduler cosine --lr 0.01 --t_max 200 --validation_epochs 5 --num_epochs 20
+python train_ssd.py --dataset_type voc  --datasets ~/data/VOC0712/VOC2007 ~/data/VOC0712/VOC2012 --validation_dataset ~/data/VOC0712/test/VOC2007/ --net mb2-ssd-lite --base_net models/mb2-imagenet-71_8.pth  --scheduler cosine --lr 0.01 --t_max 200 --validation_epochs 5 --num_epochs 200
 ```
 
 ### VGG SSD


### PR DESCRIPTION
Several people, including myself, have been confused why they are unable to reproduce the MobileNetV2 SSD on the VOC dataset with the same accuracy as reported (#46). It appears you meant to type 200 epochs instead of 20 which is not enough. 